### PR TITLE
Cambiata nuovamente logica di import dopo rilettura documentazione

### DIFF
--- a/wpc/__init__.py
+++ b/wpc/__init__.py
@@ -8,5 +8,3 @@ __version__ = '0.1.0'
 
 from wpc import repository, model, db, config, model, doc, cli
 __all__ = ["repository", "model", "db", "doc", "cli", "config"]
-
-# wpc.repository, wpc.model, wpc.db, wpc.doc, wpc.cli, wpc.config,

--- a/wpc/__init__.py
+++ b/wpc/__init__.py
@@ -5,5 +5,8 @@
 __author__ = """Luca Parolari"""
 __email__ = 'luca.parolari23@gmail.com'
 __version__ = '0.1.0'
+
 from wpc import repository, model, db, config, model, doc, cli
 __all__ = ["repository", "model", "db", "doc", "cli", "config"]
+
+# wpc.repository, wpc.model, wpc.db, wpc.doc, wpc.cli, wpc.config,

--- a/wpc/cli/__init__.py
+++ b/wpc/cli/__init__.py
@@ -1,6 +1,3 @@
-
-from .cli import cli
-
 from .client import client  # , remove as client_remove, add as client_add, edit as client_edit, show as client_show
 
 from .config import config
@@ -10,12 +7,10 @@ from .invoice import invoice
 from .work import work  # , between as work_between, show as work_show, add as work_add, remove as work_remove
 # from .work import edit  # as work_edit
 
-__all__ = ["cli", "client", "config", "invoice", "work",
+from .cli import cli
+
+__all__ = ["cli", "client", "config", "invoice", "work"
            # "work_add", "work_between", "work_edit", "work_remove", "work_show",
            # "client_add", "client_edit", "client_remove", "client_show"
            ]
-
-cli.add_command(client)
-cli.add_command(work)
-cli.add_command(invoice)
-cli.add_command(config)
+pass

--- a/wpc/cli/cli.py
+++ b/wpc/cli/cli.py
@@ -1,11 +1,13 @@
 # import wpc
 
 import click
+
 from datetime import date
 # from .client import client
 # from .work import work
 # from .invoice import invoice
 # from .config import config
+from wpc.cli import client, work, invoice, config
 
 
 @click.group()
@@ -19,6 +21,12 @@ def cli():
     Work Pay Calculator @ 2018
     """
     pass
+
+
+cli.add_command(client)
+cli.add_command(work)
+cli.add_command(invoice)
+cli.add_command(config)
 
 
 

--- a/wpc/cli/client.py
+++ b/wpc/cli/client.py
@@ -4,12 +4,13 @@ Entry point for the command line interface.
 
 import click
 
-import wpc
+# import wpc
 
-# from wpc.model.customer import Customer
-# from wpc.repository.repo import Repo
+from wpc.model.customer import Customer
+from wpc.repository.repo import Repo
 
-cli_repo = wpc.repository.Repo(wpc.model.Customer)
+cli_repo = Repo(Customer)
+
 
 @click.group()
 def client():
@@ -39,7 +40,7 @@ def show(id_, name):
             clients = [res]
     elif name is not None:
         clients = cli_repo.query()\
-                    .filter(wpc.model.Customer.name.like("%"+name+"%"))\
+                    .filter(Customer.name.like("%"+name+"%"))\
                     .all()
     else:
         clients = cli_repo.query().all()
@@ -66,7 +67,7 @@ def add():
         click.echo("Name cannot be empty")
         return
 
-    new_client = wpc.model.Customer(name=name)
+    new_client = Customer(name=name)
 
     cli_repo.create(new_client)
 

--- a/wpc/cli/client.py
+++ b/wpc/cli/client.py
@@ -4,8 +4,6 @@ Entry point for the command line interface.
 
 import click
 
-# import wpc
-
 from wpc.model.customer import Customer
 from wpc.repository.repo import Repo
 

--- a/wpc/cli/config.py
+++ b/wpc/cli/config.py
@@ -4,14 +4,14 @@ Configurations command line interface.
 
 import click
 
-# from wpc.config.configurator import Configurator
-# from wpc.repository.customerrepo import CustomerRepo
-# from wpc.model.customer import Customer
+from wpc.config.configurator import Configurator
+from wpc.repository.customerrepo import CustomerRepo
+from wpc.model.customer import Customer
 
-import wpc
+# import wpc
 
-configurator = wpc.config.Configurator()
-cust_repo = wpc.repository.CustomerRepo()
+configurator = Configurator()
+cust_repo = CustomerRepo()
 
 
 @click.command()

--- a/wpc/cli/invoice.py
+++ b/wpc/cli/invoice.py
@@ -1,7 +1,7 @@
 """
 Entry point for the command line interface.
 """
-import wpc
+# import wpc
 
 from calendar import monthrange
 from datetime import date, datetime, time
@@ -12,13 +12,15 @@ from dateutil.relativedelta import relativedelta
 from tabulate import tabulate
 
 
-# from wpc.config.configurator import Configurator
-# from wpc.doc.invoice import InvoiceTexDoc
+from wpc.config.configurator import Configurator
+from wpc.doc.invoice import InvoiceTexDoc
+from wpc.repository import WorkRepo, InvoiceRepo
+from wpc.model.invoice import Invoice
 
-work_repo = wpc.repository.WorkRepo()
-invoice_repo = wpc.repository.InvoiceRepo()
-configurator = wpc.config.Configurator()
-doc = wpc.doc.InvoiceTexDoc()
+work_repo = WorkRepo()
+invoice_repo = InvoiceRepo()
+configurator = Configurator()
+doc = InvoiceTexDoc()
 
 
 class InvoiceCli:
@@ -162,7 +164,7 @@ def add(explicit):
         click.echo("Invoice not emitted.")
         return
 
-    inv = wpc.model.Invoice.create(begin, end, gross, configurator.customer, prog, reason, tax, net, note)
+    inv = Invoice.create(begin, end, gross, configurator.customer, prog, reason, tax, net, note)
     inv.emitted_at = date_
     invoice_repo.create(inv)
 

--- a/wpc/cli/work.py
+++ b/wpc/cli/work.py
@@ -1,13 +1,13 @@
-import wpc
+# import wpc
 from datetime import date
 
 import click
 from tabulate import tabulate
 
-# from wpc.model.work import Work
-# from wpc.repository.workrepo import WorkRepo
+from wpc.model.work import Work
+from wpc.repository.workrepo import WorkRepo
 
-work_repo = wpc.repository.WorkRepo(wpc.model.Work)
+work_repo = WorkRepo(Work)
 
 
 @click.group()

--- a/wpc/config/__init__.py
+++ b/wpc/config/__init__.py
@@ -1,3 +1,4 @@
 from .configurator import Configurator
 
 __all__ = ["Configurator"]
+pass

--- a/wpc/config/configurator.py
+++ b/wpc/config/configurator.py
@@ -118,6 +118,9 @@ class Configurator(object):
             self.km_litre = str(15)
         if force or not self._cfg.has_option(self.SEC_SESSION, self.OPT_OIL_COST_LITRE):
             self.oil_cost_litre = str(1.5)
+        # TODO: added by Shub
+        if force or not self._cfg.has_option(self.SEC_SESSION, self.OPT_CUSTOMER_ID):
+            self.customer = str(1)
 
     def _do_section(self, value):
         """

--- a/wpc/db/__init__.py
+++ b/wpc/db/__init__.py
@@ -2,3 +2,4 @@ from .db import Db
 from .query import Query
 
 __all__ = ["Db", "Query"]
+pass

--- a/wpc/db/db.py
+++ b/wpc/db/db.py
@@ -1,4 +1,4 @@
-import wpc.model
+from wpc.model import Base
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -13,7 +13,7 @@ class Db:
         engine = create_engine('sqlite:///wpc.db')
         # Bind the engine to the metadata of the Base class so that the
         # declaratives can be accessed through a DBSession instance
-        wpc.model.Base.metadata.bind = engine
+        Base.metadata.bind = engine
 
         db_session = sessionmaker(bind=engine)
         # A DBSession() instance establishes all conversations with the database

--- a/wpc/doc/__init__.py
+++ b/wpc/doc/__init__.py
@@ -4,5 +4,5 @@ from .doc_tex import DocTex
 from .invoice import InvoiceTexDoc
 from .registry import RegistryDoc
 
-# __all__ = ["Doc", "DocHtml", "DocTex", "InvoiceTexDoc", "RegistryDoc"]
+__all__ = ["Doc", "DocHtml", "DocTex", "InvoiceTexDoc", "RegistryDoc"]
 pass

--- a/wpc/doc/__init__.py
+++ b/wpc/doc/__init__.py
@@ -5,3 +5,4 @@ from .invoice import InvoiceTexDoc
 from .registry import RegistryDoc
 
 __all__ = ["Doc", "DocHtml", "DocTex", "InvoiceTexDoc", "RegistryDoc"]
+pass

--- a/wpc/doc/__init__.py
+++ b/wpc/doc/__init__.py
@@ -4,5 +4,5 @@ from .doc_tex import DocTex
 from .invoice import InvoiceTexDoc
 from .registry import RegistryDoc
 
-__all__ = ["Doc", "DocHtml", "DocTex", "InvoiceTexDoc", "RegistryDoc"]
+# __all__ = ["Doc", "DocHtml", "DocTex", "InvoiceTexDoc", "RegistryDoc"]
 pass

--- a/wpc/doc/doc.py
+++ b/wpc/doc/doc.py
@@ -3,7 +3,12 @@ import os
 import re
 import subprocess
 from pathlib import Path
-from wpc.config import Configurator
+
+# TODO: Qui funziona anche
+#  from wpc.config import Configurator
+#  ma non so quale dei due sia piu' opportuno
+
+from wpc.config.configurator import Configurator
 
 
 class Doc(object):

--- a/wpc/doc/doc.py
+++ b/wpc/doc/doc.py
@@ -1,14 +1,14 @@
-import wpc
 import glob
 import os
 import re
 import subprocess
 from pathlib import Path
+from wpc.config import Configurator
 
 
 class Doc(object):
 
-    _configurator = wpc.config.Configurator()
+    _configurator = Configurator()
 
     # configurations.
     _clear_sources = True

--- a/wpc/model/__init__.py
+++ b/wpc/model/__init__.py
@@ -6,3 +6,4 @@ from .payment import Payment
 from .work import Work
 
 __all__ = ["Customer", "Invoice", "InvoiceWithHours", "Payment", "Work", "Base"]
+pass

--- a/wpc/repository/__init__.py
+++ b/wpc/repository/__init__.py
@@ -6,3 +6,4 @@ from .repo import Repo
 from .workrepo import WorkRepo
 
 __all__ = ["BaseRepo", "CrudRepo", "CustomerRepo", "InvoiceRepo", "Repo", "WorkRepo"]
+pass

--- a/wpc/repository/baserepo.py
+++ b/wpc/repository/baserepo.py
@@ -1,11 +1,12 @@
-import wpc.db
-import wpc.config
+# import wpc.db
+from wpc.config.configurator import Configurator
+from wpc.db import Db
 
 
 class BaseRepo(object):
-    _db = wpc.db.Db()
+    _db = Db()
     _clazz = None
-    _configurator = wpc.config.Configurator()
+    _configurator = Configurator()
 
     def __init__(self, clazz):
         """

--- a/wpc/repository/crudrepo.py
+++ b/wpc/repository/crudrepo.py
@@ -1,5 +1,5 @@
 from .baserepo import BaseRepo
-import wpc
+from wpc.model import Customer
 
 
 class CrudRepo(BaseRepo):
@@ -15,7 +15,7 @@ class CrudRepo(BaseRepo):
         self._s().commit()
 
     def find(self, id_):
-        return self._q().filter(wpc.model.Customer.id == id_).first()
+        return self._q().filter(Customer.id == id_).first()
 
     def getAll(self, *criterion):
         return self._q().filter(criterion).all()

--- a/wpc/repository/customerrepo.py
+++ b/wpc/repository/customerrepo.py
@@ -1,8 +1,8 @@
 from .crudrepo import CrudRepo
-import wpc
+from wpc.model import Customer
 
 
 class CustomerRepo(CrudRepo):
 
-    def __init__(self, clazz=wpc.model.Customer):
+    def __init__(self, clazz=Customer):
         super().__init__(clazz)

--- a/wpc/repository/invoicerepo.py
+++ b/wpc/repository/invoicerepo.py
@@ -1,20 +1,20 @@
 from .crudrepo import CrudRepo
-import wpc
+from wpc.model import Invoice, InvoiceWithHours
 
 from sqlalchemy import func, and_
 
 
 class InvoiceRepo(CrudRepo):
 
-    def __init__(self, clazz=wpc.model.Invoice):
+    def __init__(self, clazz=Invoice):
         super().__init__(clazz)
 
     def _q(self, clazz=None):
         q = super(CrudRepo, self)._q(clazz)
 
         if clazz is None:
-            q = q.filter(wpc.model.Invoice.customer_id == super()._configurator.customer)
-            q = q.order_by(wpc.model.Invoice.emitted_at.desc(), wpc.model.Invoice.from_dt.desc())
+            q = q.filter(Invoice.customer_id == super()._configurator.customer)
+            q = q.order_by(Invoice.emitted_at.desc(), Invoice.from_dt.desc())
 
         return q
 
@@ -27,20 +27,20 @@ class InvoiceRepo(CrudRepo):
         return self._q().all()
 
     def getAllWithHours(self):
-        return self._q(wpc.model.InvoiceWithHours) \
-            .filter(wpc.model.InvoiceWithHours.customer_id == super()._configurator.customer) \
-            .order_by(wpc.model.InvoiceWithHours.emitted_at.desc(), wpc.model.InvoiceWithHours.from_dt.desc())\
+        return self._q(InvoiceWithHours) \
+            .filter(InvoiceWithHours.customer_id == super()._configurator.customer) \
+            .order_by(InvoiceWithHours.emitted_at.desc(), InvoiceWithHours.from_dt.desc())\
             .all()
 
     def getEmittedBetweenWithHours(self, begin, end):
-        return self._q(wpc.model.InvoiceWithHours) \
-            .filter(wpc.model.InvoiceWithHours.customer_id == super()._configurator.customer) \
-            .filter(wpc.model.InvoiceWithHours.emitted_at >= begin) \
-            .filter(wpc.model.InvoiceWithHours.emitted_at <= end) \
-            .order_by(wpc.model.InvoiceWithHours.emitted_at.desc(), wpc.model.InvoiceWithHours.from_dt.desc())\
+        return self._q(InvoiceWithHours) \
+            .filter(InvoiceWithHours.customer_id == super()._configurator.customer) \
+            .filter(InvoiceWithHours.emitted_at >= begin) \
+            .filter(InvoiceWithHours.emitted_at <= end) \
+            .order_by(InvoiceWithHours.emitted_at.desc(), InvoiceWithHours.from_dt.desc())\
             .all()
 
     def getNextProg(self):
-        max_ = self._q().with_entities(func.max(wpc.model.Invoice.prog).label('max')).first().max
+        max_ = self._q().with_entities(func.max(Invoice.prog).label('max')).first().max
         max_ = max_ if max_ is not None else 0
         return max_ + 1

--- a/wpc/repository/workrepo.py
+++ b/wpc/repository/workrepo.py
@@ -2,26 +2,13 @@ from functools import reduce
 from datetime import datetime, date, timedelta
 from calendar import monthrange
 
-# TODO: questi import relativi sono necessari perche' il primo __init__.py del package wpc
-#  effettua l'importazione dei subpackage in dato ordine, e se alcuni moduli, come questo,
-#  si riferiscono a classi o funzioni dello stesso livello, dello stesso subpackage,
-#  l' "import wpc" generico non funziona perche' per python questo subpackage non e' stato
-#  ancora inizializzato completamente ed inserito nel dizionario.
-
 from .crudrepo import CrudRepo
-
-# TODO: questo import relativo si evita con il seguente "import wpc":
-#  from ..config.configurator import Configurator
-#  Ma funziona solo se wpc.config e' stato gia' correttamente inzializzato
-
 from wpc.model import Work
 from wpc.config import Configurator
 
 
 class WorkRepo(CrudRepo):
 
-    # TODO: l'eliminazione dell'import relativo di cui sopra richiede ora
-    #  un riferimeno "FQDN"
     _configurator = Configurator()
 
     def __init__(self, clazz=Work):

--- a/wpc/repository/workrepo.py
+++ b/wpc/repository/workrepo.py
@@ -14,16 +14,17 @@ from .crudrepo import CrudRepo
 #  from ..config.configurator import Configurator
 #  Ma funziona solo se wpc.config e' stato gia' correttamente inzializzato
 
-import wpc
+from wpc.model import Work
+from wpc.config import Configurator
 
 
 class WorkRepo(CrudRepo):
 
     # TODO: l'eliminazione dell'import relativo di cui sopra richiede ora
     #  un riferimeno "FQDN"
-    _configurator = wpc.config.Configurator()
+    _configurator = Configurator()
 
-    def __init__(self, clazz=wpc.model.Work):
+    def __init__(self, clazz=Work):
         super().__init__(clazz)
 
     def _q(self, clazz=None):
@@ -33,16 +34,16 @@ class WorkRepo(CrudRepo):
         """
         # TODO: implement clazz logic.
         return super(CrudRepo, self)._q()\
-            .filter(wpc.model.Work.customer_id == super()._configurator.customer)\
-            .order_by(wpc.model.Work.begin.desc(), wpc.model.Work.end.asc())
+            .filter(Work.customer_id == super()._configurator.customer)\
+            .order_by(Work.begin.desc(), Work.end.asc())
 
     def getAll(self, *criterion):
         return self._q().all()
 
     def getBetween(self, begin, end):
         return self._q() \
-            .filter(wpc.model.Work.begin >= begin) \
-            .filter(wpc.model.Work.end <= end) \
+            .filter(Work.begin >= begin) \
+            .filter(Work.end <= end) \
             .all()
 
     def getBetweenStart(self, begin, end):
@@ -52,8 +53,8 @@ class WorkRepo(CrudRepo):
         :return: A list of works between ``begin`` and ``end``, ``end`` excluded.
         """
         return self._q() \
-            .filter(wpc.model.Work.begin >= begin) \
-            .filter(wpc.model.Work.begin < end) \
+            .filter(Work.begin >= begin) \
+            .filter(Work.begin < end) \
             .all()
 
     def getProfitGrossBetween(self, begin, end):

--- a/wpc/shell_cli.py
+++ b/wpc/shell_cli.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # import wpc
-from .cli import cli
+from wpc.cli import cli
 
 if __name__ == "__main__":
     cli.cli()

--- a/wpc/shell_cli.py
+++ b/wpc/shell_cli.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# import wpc
+
 from wpc.cli import cli
 
 if __name__ == "__main__":


### PR DESCRIPTION
Ora utilizzo gli import `from` "assoluti", come `from wpc.model.customer import Customer`, nei file `__init__.py`, come indicato dalla documentazione nel caso un modulo in una sottodirectory debba accedere a risorse di un altro modulo dello stesso package (es. `wpc`) in un'altra sottodirectory.